### PR TITLE
Fix an issue with block comments

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -110,7 +110,7 @@ function init(input, opts) {
 }
 
 function enable(code, opts) {
-  return code.replace(new RegExp('[^*]' + _regexp(opts), 'g'), '(function(){/*$1*/})');
+    return code.replace(/\/\*([\s\S]*?)\*\//g, '').replace(new RegExp('[^*]' + _regexp(opts), 'g'), '(function(){/*$1*/})');
 }
 
 function restore(code, opts) {


### PR DESCRIPTION
Removing alle  block comments before replace loggings.

The BaseController (__project__/Resources/iphone/alloy/controllers/BaseController.js)
has within a block comment a console output command.

Before transformation:
`/*
console.log();
*/`

After  transformation:
`/*
/*console.log();*/
*/`

This kind of comments cannot be nested, so removing them before..